### PR TITLE
Add a 4.6.0 spec test to the matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,41 @@
+---
+stages:
+  - syntax
+  - unit
+
+cache:
+  paths:
+    - vendor/bundle
+
+before_script:
+  - bundle -v
+  - rm Gemfile.lock || true
+  - gem update --system
+  - gem --version
+  - bundle -v
+  - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
+
+parallel_spec-Ruby 2.1.9-Puppet ~> 4.0:
+  stage: syntax
+  image: ruby:2.1.9
+  script:
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 4.0'
+
+syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.4.4-Puppet ~> 5.5:
+  stage: syntax
+  image: ruby:2.4.4
+  script:
+    - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
+  variables:
+    PUPPET_GEM_VERSION: '~> 5.5'
+
+parallel_spec-Ruby 2.4.4-Puppet ~> 5.5:
+  stage: syntax
+  image: ruby:2.4.4
+  script:
+    - bundle exec rake parallel_spec
+  variables:
+    PUPPET_GEM_VERSION: '~> 5.5'
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,11 +8,14 @@ AllCops:
   Exclude:
   - bin/*
   - ".vendor/**/*"
-  - Gemfile
-  - Rakefile
+  - "**/Gemfile"
+  - "**/Rakefile"
   - pkg/**/*
   - spec/fixtures/**/*
   - vendor/**/*
+  - "**/Puppetfile"
+  - "**/Vagrantfile"
+  - "**/Guardfile"
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
@@ -65,6 +68,11 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 RSpec/MessageSpies:
   EnforcedStyle: receive
+Style/Documentation:
+  Exclude:
+  - lib/puppet/parser/functions/**/*
+Style/WordArray:
+  EnforcedStyle: brackets
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,7 +1,12 @@
 ---
+mock_with: ':rspec'
+
+.travis.yml:
+  includes:
+    - env: PUPPET_GEM_VERSION="= 4.6.1" CHECK=parallel_spec
+      rvm: 2.1.9
+
 appveyor.yml:
-  delete: true
-.gitlab-ci.yml:
   delete: true
 .project:
   delete: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - bundle -v
   - rm -f Gemfile.lock
   - gem update --system
-  - gem update bundler
   - gem --version
   - bundle -v
 script:
@@ -16,22 +15,20 @@ bundler_args: --without system_tests
 rvm:
   - 2.4.1
 env:
-  - PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  global:
+    - BEAKER_PUPPET_COLLECTION=puppet5 PUPPET_GEM_VERSION="~> 5.0"
 matrix:
   fast_finish: true
   include:
     -
-      env: CHECK=rubocop
+      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
     -
-      env: CHECK="syntax lint"
+      env: CHECK=parallel_spec
     -
-      env: CHECK=metadata_lint
+      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=parallel_spec
+      rvm: 2.1.9
     -
-      env: CHECK=release_checks
-    -
-      env: CHECK=spec
-    -
-      env: PUPPET_GEM_VERSION="~> 4.0" CHECK=spec
+      env: PUPPET_GEM_VERSION="= 4.6.1" CHECK=parallel_spec
       rvm: 2.1.9
 branches:
   only:

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ group :development do
   gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.3')
+  gem "json", '<= 2.0.4',                              require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.4.4')
   gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]

--- a/Rakefile
+++ b/Rakefile
@@ -2,4 +2,5 @@ require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
 
-PuppetLint.configuration.send('relative')
+PuppetLint.configuration.send('disable_relative')
+

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,7 @@
   "source": "https://github.com/npwalker/recursive_file_permissions",
   "project_page": "https://github.com/npwalker/recursive_file_permissions",
   "dependencies": [
+
   ],
   "operatingsystem_support": [
     {
@@ -86,7 +87,7 @@
       "version_requirement": ">= 4.6.0 < 6.0.0"
     }
   ],
-  "pdk-version": "1.5.0.pre (gde5476b)",
-  "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",
-  "template-ref": "heads/master-0-g033771c"
+  "pdk-version": "1.6.0.pre (heads/master-0-g1c719d9)",
+  "template-url": "https://github.com/puppetlabs/pdk-templates",
+  "template-ref": "heads/master-0-g34e3266"
 }

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'recursive_file_permissions' do
-  let(:title) { '/tmp' }
+  let(:title) { '/tmp/blah' }
   let(:params) do
     {
       'file_mode'  => '0644',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
 
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'


### PR DESCRIPTION
Currently the default .travis.yml from PDK tests against the latest
4 and latest 5 release.  We state compatibility back to 4.6.0 so
we should test that.