### PR TITLE
Fix execute chown and chgrp for symlink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system
+  - gem i rubygems-update -v '<3' && update_rubygems
   - gem --version
   - bundle -v
 script:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,13 @@ define recursive_file_permissions(
     default:          { '-c'  } # Beautifully verbose output
   }
 
+  # -h --no-dereference
+  # affect each symbolic link instead of any referenced file
+  # (useful only on systems that can change the ownership/group of a symlink)
+  $h = case $facts['os']['family'] {
+    default: { '-h' }
+  }
+
   $validators = [
     { input  => $file_mode,
       find   => shellquote('(', '-type', 'f', '!', '-perm', $file_mode, ')'),
@@ -51,11 +58,11 @@ define recursive_file_permissions(
     },
     { input => $owner,
       find  => shellquote('(', '!', '-user', $owner, ')'),
-      fix   => "-exec chown ${v} ${shellquote($owner)} {}  \\;",
+      fix   => "-exec chown ${v} ${h} ${shellquote($owner)} {}  \\;",
     },
     { input => $group,
       find  => shellquote('(', '!', '-group', $group, ')'),
-      fix   => "-exec chgrp ${v} ${shellquote($group)} {} \\;",
+      fix   => "-exec chgrp ${v} ${h} ${shellquote($group)} {} \\;",
     },
   ]
 


### PR DESCRIPTION
### Description

Used resource:

```puppet 
recursive_file_permissions { '/usr/lib/one/sunstone':
    file_mode => '0644',
    dir_mode  => '0755',
    owner     => 'root',
    group     => 'oneadmin',
}
```
exec:

```shell
find /usr/lib/one/sunstone "(" -type f '!' -perm 0644 ")" \
-o "(" -type d '!' -perm 0755 ")" \
-o "(" '!' -user root ")" \
-o "(" '!' -group oneadmin ")" | grep '.*'
```

result:

```shell
/usr/lib/one/sunstone/public/dist/main.js
```

this is symlink:

```shell
ls -la main.js
lrwxrwxrwx 1 oneadmin oneadmin 29 Apr  7 15:21 main.js -> /var/lib/one/sunstone/main.js
```
The next step is to run the `chown` command for the file `/usr/lib/one/sunstone/public/dist/main.js`, which modifies `/var/lib/one/sunstone/main.js`. But next time the puppet will find the given file again. (**recursive loop**).

The resource should change the symlink, not the file that she points to.

### Fixes

Use the -h option for chown and chgrp. This option is supported by all operating systems for which support for this module is claimed.

```man
--dereference
affect the referent of each symbolic link (this is the default),
rather than the symbolic link itself

-h, --no-dereference
affect each symbolic link instead of any referenced file
(useful only on systems that can change the ownership/group of a symlink)
```